### PR TITLE
Formatting changes: multiline binaries

### DIFF
--- a/src/tqlayout.erl
+++ b/src/tqlayout.erl
@@ -91,7 +91,7 @@ do_layout_expr({record, _, Expr, Name, Values}) ->
            , container_o(Values, tqpp:t("{"), tqpp:t("}"))
            ]);
 do_layout_expr({bin, _, Values}) ->
-  tqpp:cat([tqpp:t("<"), container(Values, tqpp:t("<"), tqpp:t(">>"))]);
+  tqpp:cat([tqpp:t("<"), container_o(Values, tqpp:t("<"), tqpp:t(">>"))]);
 do_layout_expr({'...', _}) -> tqpp:t("...");
 do_layout_expr({'try', _, Exprs, OfClauses, CatchClauses, After}) ->
   layout_try_expr(Exprs, OfClauses, CatchClauses, After);

--- a/test/data/inline_items.formatted
+++ b/test/data/inline_items.formatted
@@ -240,7 +240,7 @@ long_bin() ->
        , 333333333333333333
        , 333333333333333333
        , 333333333333333333
-       >>,
+      >>,
   Y = << 1:1
        , 1:1
        , 1:1
@@ -253,7 +253,7 @@ long_bin() ->
        , 3/float
        , 3/float
        , 3/float
-       >>,
+      >>,
   << X/binary
    , Y/binary
    , X/binary
@@ -264,7 +264,7 @@ long_bin() ->
    , Y/binary
    , X/binary
    , Y/binary
-   >>.
+  >>.
 
 -spec long_guard(integer()) -> integer().
 long_guard(VeryVeryLongName) when

--- a/test/data/test.formatted
+++ b/test/data/test.formatted
@@ -8,4 +8,4 @@ a_fun() -> x.
 what_about_multiline_binaries() ->
   << "foo"
      "bar"
-   >>.
+  >>.

--- a/test/data/test.formatted
+++ b/test/data/test.formatted
@@ -4,3 +4,8 @@
 
 -spec a_fun() -> error().
 a_fun() -> x.
+
+what_about_multiline_binaries() ->
+  << "foo"
+     "bar"
+   >>.

--- a/test/data/test.orig
+++ b/test/data/test.orig
@@ -4,3 +4,8 @@
 -spec a_fun() -> error().
 a_fun() ->
     x.
+
+what_about_multiline_binaries() ->
+  << "foo"
+     "bar"
+   >>.


### PR DESCRIPTION
Deal with multiline binaries in a more consistent way, better matching what emacs does and what feels internally consistent.