### PR TITLE
Fix layout of multiple after exprs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        erl: [21, 22, 23]
+        erl: [22, 23, 24]
 
     container:
       image: erlang:${{ matrix.erl }}

--- a/src/tqlayout.erl
+++ b/src/tqlayout.erl
@@ -210,7 +210,7 @@ layout_catch([]) -> [];
 layout_catch(Clauses) -> [before_block(tqpp:t("catch"), layout_clauses(Clauses))].
 
 layout_after([]) -> [];
-layout_after(Clauses) -> [before_block(tqpp:t("after"), layout_clauses(Clauses))].
+layout_after(Exprs) -> [before_block(tqpp:t("after"), layout_block(Exprs))].
 
 -spec call([any()]) -> tqpp:document().
 call(Args) -> container(Args, tqpp:t("("), tqpp:t(")")).

--- a/test/data/others.formatted
+++ b/test/data/others.formatted
@@ -67,3 +67,10 @@ multi_try_expr() ->
     expressions:in(this_block)
   catch A:Catch:Expression -> formatter:should(indent, A, Catch, Expression)
   end.
+
+multi_after_expr() ->
+  try some_fn()
+  after
+    do_one(),
+    do_two()
+  end.

--- a/test/data/others.orig
+++ b/test/data/others.orig
@@ -61,3 +61,8 @@ multi_try_expr() ->
     try there:are(2), expressions:in(this_block) catch
         A:Catch:Expression -> formatter:should(indent,A,Catch,Expression)
     end.
+
+multi_after_expr() ->
+  try some_fn() after
+    do_one(), do_two()
+  end.


### PR DESCRIPTION
## Input

```erlang
experiment() ->
  try some_fn() after
    do_one(), do_two()
  end.
```

## Before this change

```erlang
experiment() ->
  try some_fn()
  after
    do_one();
    do_two()
  end.
```

This is clearly wrong: `do_one()` and `do_two()` should be separated by commas!

## After this change

```erlang
experiment() ->
  try some_fn()
  after
    do_one(),
    do_two()
  end.
```

There we go :)